### PR TITLE
Add monochrome icon for Android 13

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/app_icon.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/app_icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/app_icon_background" />
     <foreground android:drawable="@drawable/app_icon_foreground" />
+    <monochrome android:drawable="@drawable/app_icon_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
I figured out I could just do this myself.

Fixes #49 