### PR TITLE
Fix monochrome icon

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/app_icon_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/app_icon_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/app_icon_background" />
     <foreground android:drawable="@drawable/app_icon_foreground" />
+    <monochrome android:drawable="@drawable/app_icon_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
It seems I managed to go wrong with such a tiny change. I'm not an (Android) dev, so I can only copy what I see from here and there, without particular understanding. This time I tested locally, and I can assure it works. Sorry for that.